### PR TITLE
Update manifest file to support latest version of Home Assistant

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,5 +4,6 @@
   "version": "1.0",
   "documentation": "None",
   "requirements": ["pyserial==3.5"],
-  "codeowners": []
+  "codeowners": [],
+  "config_flow": false
 }


### PR DESCRIPTION
This update of the manifest file will make the integration work under the latest Home Assistant version